### PR TITLE
Close unclosed if statements in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -511,6 +511,9 @@ configure_container() {
                     echo ""
                 fi
             done
+        fi
+    fi
+
     echo ""
     read -p "Take a snapshot after container creation? (Y/n): " snap_choice
     snap_choice=${snap_choice:-Y}


### PR DESCRIPTION
There's a syntax error in the install script, which causes bash to complain about an unexpected `}` on line 520. As far as I can tell this is because of the two unclosed if statements this PR closes.