### PR TITLE
feat: unprivileged LXC, minimal iGPU passthrough, firewall, YOLO, secured Samba

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ A fully automated, one-command script for deploying [Frigate NVR](https://frigat
 This script builds a production-ready Frigate stack from scratch: provisioning the LXC container, installing Docker, and automatically configuring hardware acceleration.
 
 ### What it does:
-✅ **Full Stack Provisioning** - Creates a privileged LXC container with Docker and Compose pre-installed  
+✅ **Full Stack Provisioning** - Creates an unprivileged LXC container with Docker and Compose pre-installed  
 ✅ **GPU Accelerated** - Configures Intel iGPU acceleration by default (VAAPI/QSV)  
 ✅ **Alder Lake-N Optimized** - Tailored for Intel N95, N100, and **N150** processors  
-✅ **Zero Manual Setup** - Handles all the complex nesting, keyctl, and driver passthrough settings
+✅ **Zero Manual Setup** - Handles nesting, keyctl, and minimal GPU passthrough settings
 
 ![](images/1.1.png)
 ![](images/2.1.png)
@@ -22,7 +22,7 @@ This script builds a production-ready Frigate stack from scratch: provisioning t
 ✅ **Hardware Auto-Detection** - Automatically identifies CPU, GPU, and Coral TPU  
 ✅ **Easy Updates** - Simple Docker pulls to keep your NVR current  
 ✅ **Home Assistant Ready** - Default ports and paths pre-configured  
-✅ **Add-ons Included** - Optional SSH & Samba for easy file management  
+✅ **Add-ons Included** - Optional SSH access for easy management  
 
 ## Requirements
 
@@ -142,51 +142,6 @@ Starting in Frigate 0.14+, you can edit the configuration directly in the web in
 
 </details>
 
-<details>
-<summary><h3>Samba Network File Sharing</h3></summary>
-
-If you enabled Samba during installation, you can access and edit Frigate files directly from your computer using network file shares.
-
-**Available Shares:**
-
-1. **`\\<CONTAINER_IP>\Frigate`** - Full Frigate installation directory (`/opt/frigate`)
-2. **`\\<CONTAINER_IP>\Config`** - Configuration files only (`/opt/frigate/config`)
-3. **`\\<CONTAINER_IP>\Media`** - Recordings and snapshots (`/opt/frigate/storage`)
-
-**How to Connect:**
-
-**Windows:**
-1. Open File Explorer
-2. Type in the address bar: `\\<CONTAINER_IP>\Config`
-3. Press Enter
-4. Navigate to `config.yml` and edit with your favorite text editor
-
-**macOS:**
-1. Open Finder
-2. Press `Cmd + K` (or Go → Connect to Server)
-3. Enter: `smb://<CONTAINER_IP>/Config`
-4. Click Connect
-5. Edit `config.yml` in any text editor
-
-**Linux:**
-```bash
-# Mount the share
-sudo mount -t cifs //<CONTAINER_IP>/Config /mnt/frigate -o guest
-
-# Edit config
-nano /mnt/frigate/config.yml
-```
-
-**Share Details:**
-- **Authentication**: Guest access enabled (no password required by default)
-- **Password**: If you configured Samba during installation, you can also authenticate with:
-  - Username: `root`
-  - Password: The root password you set during installation
-- **Permissions**: Full read/write access
-- **User**: All files created as `root` user automatically
-
-</details>
-
 ### File Locations
 
 ```
@@ -238,9 +193,11 @@ pct exec <CT_ID> -- ls -l /dev/dri/renderD128
 # View Frigate logs for hardware acceleration status
 pct exec <CT_ID> -- docker logs frigate 2>&1 | grep -i vaapi
 
-# View GPU usage
+# View GPU usage (run on the Proxmox HOST, not inside the container)
 sudo intel_gpu_top
 ```
+
+> **Note:** Because this script uses an **unprivileged LXC container**, GPU statistics are not accessible from inside the container. Hardware acceleration (VAAPI/QSV/OpenVINO) still works correctly — you can verify it via Frigate logs. Run `intel_gpu_top` on the Proxmox host instead.
 
 ### Example Config with Hardware Acceleration
 
@@ -419,7 +376,7 @@ This project is a personal automation script designed primarily for **Intel iGPU
 
 - **Primary Support**: Hardware detection and setup issues for Intel iGPU configurations.
 - **Experimental Support**: NVIDIA and AMD GPU configurations. These are included as a convenience but often require host-level driver troubleshooting that falls outside the scope of this project.
-- **Out of Scope**: Individual network troubleshooting, remote storage (NFS/SMB) mounting issues, or complex Docker network configurations.
+- **Out of Scope**: Individual network troubleshooting, remote storage (NFS) mounting issues, or complex Docker network configurations.
 
 If you are using non-Intel hardware, please ensure your host-side drivers are fully functional before reporting an issue.
 

--- a/install.sh
+++ b/install.sh
@@ -34,12 +34,13 @@ echo -ne "\033]0;Frigate Proxmox Script\007"
 # Container Configuration
 CT_ID=""
 CT_HOSTNAME="frigate"
-CT_PRIVILEGED=1  # Must be privileged for iGPU passthrough
+CT_PRIVILEGED=0  # Security default: use unprivileged LXC
 CT_CORES=4
 CT_RAM=2048
 CT_DISK=10
 CT_STORAGE=""
 CT_VLAN=""
+CT_MTU=""
 CT_BRIDGE="vmbr0"
 CT_NETWORK_TYPE="dhcp"
 CT_IP=""
@@ -59,7 +60,9 @@ SHM_SIZE="256mb"
 ENABLE_SSH="no"
 SSH_USER="root"
 SSH_PASSWORD=""
+ENABLE_FIREWALL="yes"
 ENABLE_SAMBA="no"
+SAMBA_PASSWORD=""
 ROOT_PASSWORD=""
 DO_SNAPSHOT=false
 SNAPSHOT_NAME=""
@@ -74,6 +77,10 @@ DETECTED_RENDER_NODES=() # Array to store found render nodes
 SELECTED_RENDER_NODE="/dev/dri/renderD128"
 DETECTED_CORAL="none"
 GPU_PRESET="preset-vaapi" # Default to VAAPI (Intel/AMD)
+ENABLE_YOLO_MODEL=false
+YOLO_MODEL_SIZE="s"
+YOLO_IMG_SIZE="640"
+YOLO_MODEL_PATH=""
 
 # ============================================================================
 # HELPER FUNCTIONS
@@ -312,10 +319,11 @@ check_resources() {
     fi
 
     local avail_gb=$((avail / 1024 / 1024))
-    
+    local pct_int=${pct%%.*}
+
     if [ "$avail_gb" -lt 10 ]; then
         log_warn "Low space on pool '$CT_STORAGE': Only ${avail_gb}GB available. Recommended: 10GB+ for rootfs."
-    elif [ "$pct" -gt 90 ]; then
+    elif [ "$pct_int" -gt 90 ]; then
         log_warn "Storage pool '$CT_STORAGE' is ${pct}% full. This may cause issues during operation."
     else
         log_success "Storage pool '$CT_STORAGE' has ${avail_gb}GB available (${pct}% used)."
@@ -451,12 +459,12 @@ configure_container() {
     
     # Container ID
     while true; do
-        read -p "Enter Container ID [100-999] (default: auto): " input_id
+        read -p "Enter Container ID [100-9999] (default: auto): " input_id
         if [ -z "$input_id" ]; then
             CT_ID=$(pvesh get /cluster/nextid)
             log "Auto-selected Container ID: $CT_ID"
             break
-        elif [[ "$input_id" =~ ^[0-9]+$ ]] && [ "$input_id" -ge 100 ] && [ "$input_id" -le 999 ]; then
+        elif [[ "$input_id" =~ ^[0-9]+$ ]] && [ "$input_id" -ge 100 ] && [ "$input_id" -le 9999 ]; then
             if pct status "$input_id" &>/dev/null; then
                 log_error "Container ID $input_id already exists!"
             else
@@ -464,7 +472,7 @@ configure_container() {
                 break
             fi
         else
-            log_error "Invalid Container ID. Must be between 100-999."
+            log_error "Invalid Container ID. Must be between 100-9999."
         fi
     done
     
@@ -510,6 +518,33 @@ configure_container() {
 
     echo ""
     echo "Network Configuration:"
+
+    # Detect available Linux bridges
+    local available_bridges
+    mapfile -t available_bridges < <(ip link show type bridge 2>/dev/null | awk -F': ' '/^[0-9]+:/{print $2}' | sed 's/@.*//' | grep '^vmbr')
+    if [ ${#available_bridges[@]} -eq 0 ]; then
+        read -p "Enter network bridge (e.g., vmbr0): " input_bridge
+        CT_BRIDGE="${input_bridge:-vmbr0}"
+    elif [ ${#available_bridges[@]} -eq 1 ]; then
+        CT_BRIDGE="${available_bridges[0]}"
+        echo "  Network Bridge:  $CT_BRIDGE (auto-detected)"
+    else
+        echo "  Available bridges:"
+        for i in "${!available_bridges[@]}"; do
+            echo "    $((i+1))) ${available_bridges[$i]}"
+        done
+        while true; do
+            read -p "Select network bridge [1-${#available_bridges[@]}] (default: 1): " bridge_choice
+            bridge_choice=${bridge_choice:-1}
+            if [[ "$bridge_choice" =~ ^[0-9]+$ ]] && [ "$bridge_choice" -ge 1 ] && [ "$bridge_choice" -le "${#available_bridges[@]}" ]; then
+                CT_BRIDGE="${available_bridges[$((bridge_choice-1))]}"
+                break
+            else
+                log_error "Invalid selection."
+            fi
+        done
+    fi
+
     echo "  1) DHCP (automatic)"
     echo "  2) Static IP"
     read -p "Select network type (1/2): " net_choice
@@ -522,6 +557,24 @@ configure_container() {
         CT_DNS="${input_dns:-8.8.8.8}"
     else
         CT_NETWORK_TYPE="dhcp"
+    fi
+
+    read -p "Enter VLAN tag (optional, press Enter to skip): " input_vlan
+    if [ -n "$input_vlan" ]; then
+        if [[ "$input_vlan" =~ ^[0-9]+$ ]] && [ "$input_vlan" -ge 1 ] && [ "$input_vlan" -le 4094 ]; then
+            CT_VLAN="$input_vlan"
+        else
+            log_warn "Invalid VLAN tag '$input_vlan' (must be 1-4094). Skipping."
+        fi
+    fi
+
+    read -p "Enter MTU (optional, press Enter for default): " input_mtu
+    if [ -n "$input_mtu" ]; then
+        if [[ "$input_mtu" =~ ^[0-9]+$ ]] && [ "$input_mtu" -ge 576 ] && [ "$input_mtu" -le 9000 ]; then
+            CT_MTU="$input_mtu"
+        else
+            log_warn "Invalid MTU '$input_mtu' (must be 576-9000). Skipping."
+        fi
     fi
     
     echo ""
@@ -609,7 +662,7 @@ configure_container() {
         fi
         
         # Validate format (number followed by b, k, m, g)
-        if [[ ! "$input_shm" =~ ^[0-9]+[bk m g]b?$ ]]; then
+        if [[ ! "$input_shm" =~ ^[0-9]+([bkmg]|[bkmg]b)$ ]]; then
             log_error "Invalid SHM size format! Use e.g. 512mb, 1gb, 256m"
             continue
         fi
@@ -667,7 +720,51 @@ configure_container() {
     esac
     
     echo ""
-    
+
+    # YOLOv9 model (only for OpenVINO-capable GPUs)
+    if [ "$SELECTED_GPU_TYPE" = "intel" ] || [ "$SELECTED_GPU_TYPE" = "amd" ] || [ "$SELECTED_GPU_TYPE" = "vaapi" ]; then
+        echo ""
+        echo -n "Use custom YOLOv9 model (OpenVINO)? More accurate than default SSD. (y/N): "
+        read -r yolo_choice
+        if [[ "$yolo_choice" =~ ^[Yy]$ ]]; then
+            ENABLE_YOLO_MODEL=true
+            echo ""
+            echo "Model size (larger = more accurate, slower on iGPU):"
+            echo " 1) t - Tiny    (fastest)"
+            echo " 2) s - Small   [recommended]"
+            echo " 3) m - Medium"
+            echo " 4) c - Large"
+            echo " 5) e - Extra Large (slowest)"
+            while true; do
+                read -p "Select [1-5] (default: 2): " size_choice
+                size_choice=${size_choice:-2}
+                case "$size_choice" in
+                    1) YOLO_MODEL_SIZE="t"; break ;;
+                    2) YOLO_MODEL_SIZE="s"; break ;;
+                    3) YOLO_MODEL_SIZE="m"; break ;;
+                    4) YOLO_MODEL_SIZE="c"; break ;;
+                    5) YOLO_MODEL_SIZE="e"; break ;;
+                    *) log_error "Invalid selection" ;;
+                esac
+            done
+            echo ""
+            echo "Image size:"
+            echo " 1) 320 (faster)"
+            echo " 2) 640 (more accurate) [recommended]"
+            while true; do
+                read -p "Select [1-2] (default: 2): " img_choice
+                img_choice=${img_choice:-2}
+                case "$img_choice" in
+                    1) YOLO_IMG_SIZE="320"; break ;;
+                    2) YOLO_IMG_SIZE="640"; break ;;
+                    *) log_error "Invalid selection" ;;
+                esac
+            done
+            YOLO_MODEL_PATH="/config/model_cache/yolo/yolov9-${YOLO_MODEL_SIZE}-${YOLO_IMG_SIZE}.onnx"
+            log_success "YOLOv9-${YOLO_MODEL_SIZE} at ${YOLO_IMG_SIZE}px selected (export runs after installation)"
+        fi
+    fi
+
     echo ""
     echo ""
     log_step "Security Configuration"
@@ -710,35 +807,34 @@ configure_container() {
     fi
     
     echo ""
-    read -p "Enable Samba file sharing? (Y/n): " enable_samba
-    enable_samba=${enable_samba:-Y}
+    read -p "Enable Samba file sharing (config & storage only, password required)? (y/N): " enable_samba
+    enable_samba=${enable_samba:-N}
     if [[ "$enable_samba" =~ ^[Yy]$ ]]; then
         ENABLE_SAMBA="yes"
-        
-        # If SSH is disabled, we need to ask for a Samba password specifically
-        if [ "$ENABLE_SSH" != "yes" ]; then
+        while true; do
+            read -sp "Enter Samba password for user 'frigate': " SAMBA_PASSWORD
             echo ""
-            log_warn "Samba enabled but SSH disabled. You need to set a Samba password."
-            while true; do
-                read -sp "Enter Samba password: " SSH_PASSWORD
-                echo ""
-                
-                if [ -z "$SSH_PASSWORD" ]; then
-                    log_error "Password cannot be empty!"
-                    continue
-                fi
-                
-                read -sp "Confirm Samba password: " SAMBA_PASSWORD_CONFIRM
-                echo ""
-                
-                if [ "$SSH_PASSWORD" = "$SAMBA_PASSWORD_CONFIRM" ]; then
-                    break
-                else
-                    log_error "Passwords do not match! Please try again."
-                    echo ""
-                fi
-            done
-        fi
+            if [ -z "$SAMBA_PASSWORD" ]; then
+                log_error "Password cannot be empty!"
+                continue
+            fi
+            read -sp "Confirm Samba password: " samba_confirm
+            echo ""
+            if [ "$SAMBA_PASSWORD" = "$samba_confirm" ]; then
+                break
+            else
+                log_error "Passwords do not match! Please try again."
+            fi
+        done
+    fi
+
+    echo ""
+    read -p "Enable Proxmox firewall on container (opens port $FRIGATE_PORT)? (Y/n): " enable_fw
+    enable_fw=${enable_fw:-Y}
+    if [[ "$enable_fw" =~ ^[Yy]$ ]]; then
+        ENABLE_FIREWALL="yes"
+    else
+        ENABLE_FIREWALL="no"
     fi
 
     echo ""
@@ -759,7 +855,7 @@ show_configuration_summary() {
     echo "Container Settings:"
     echo "  ID:              $CT_ID"
     echo "  Hostname:        $CT_HOSTNAME"
-    echo "  Type:            Privileged LXC"
+    echo "  Type:            Unprivileged LXC"
     echo "  CPU Cores:       $CT_CORES"
     echo "  RAM:             ${CT_RAM}MB"
     echo "  Disk:            ${CT_DISK}GB"
@@ -770,6 +866,9 @@ show_configuration_summary() {
     echo "  Network Bridge:  $CT_BRIDGE"
     if [ -n "$CT_VLAN" ]; then
         echo "  VLAN Tag:        $CT_VLAN"
+    fi
+    if [ -n "$CT_MTU" ]; then
+        echo "  MTU:             $CT_MTU"
     fi
     echo "  Network Type:    $CT_NETWORK_TYPE"
     if [ "$CT_NETWORK_TYPE" = "static" ]; then
@@ -788,12 +887,16 @@ show_configuration_summary() {
     echo "  go2rtc Port:     $GO2RTC_PORT"
     echo "  Auth Port:       $AUTH_PORT"
     echo "  SHM Size:        $SHM_SIZE"
+    if [ "$ENABLE_YOLO_MODEL" = true ]; then
+        echo "  YOLO Model:      YOLOv9-${YOLO_MODEL_SIZE} @ ${YOLO_IMG_SIZE}px (OpenVINO)"
+    fi
     if [ "$ENABLE_SSH" = "yes" ]; then
         echo "  SSH User:        $SSH_USER"
     fi
     if [ "$ENABLE_SAMBA" = "yes" ]; then
-        echo "  Samba:           Enabled (3 shares)"
+        echo "  Samba:           Enabled (user: frigate, shares: Config + Storage)"
     fi
+    echo "  Firewall:        $ENABLE_FIREWALL"
     echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo ""
@@ -855,13 +958,21 @@ download_debian_template() {
 create_lxc_container() {
     log_step "Creating LXC container $CT_ID ($CT_HOSTNAME)..."
     
-    local net_config="name=eth0,bridge=$CT_BRIDGE,ip=$CT_NETWORK_TYPE"
+    local net_config="name=eth0,bridge=$CT_BRIDGE"
     if [ "$CT_NETWORK_TYPE" = "static" ]; then
-        net_config="$net_config=$CT_IP,gw=$CT_GATEWAY"
+        net_config="$net_config,ip=$CT_IP,gw=$CT_GATEWAY"
+    else
+        net_config="$net_config,ip=dhcp"
     fi
     
     if [ -n "$CT_VLAN" ]; then
         net_config="$net_config,tag=$CT_VLAN"
+    fi
+    if [ -n "$CT_MTU" ]; then
+        net_config="$net_config,mtu=$CT_MTU"
+    fi
+    if [ "$ENABLE_FIREWALL" = "yes" ]; then
+        net_config="$net_config,firewall=1"
     fi
 
     local password_part=""
@@ -879,8 +990,8 @@ create_lxc_container() {
             --net0 "$net_config" \
             --onboot 1 \
             --ostype debian \
-            --unprivileged 0 \
-            --features nesting=1 \
+            --unprivileged 1 \
+            --features nesting=1,keyctl=1 \
             $password_part 2>&1 | tee -a "$LOG_FILE" || error_exit "Failed to create container"
         
         log_success "Container created"
@@ -916,22 +1027,40 @@ configure_igpu_passthrough() {
         return
     fi
     
-    log_step "Configuring Intel iGPU passthrough..."
+    log_step "Configuring minimal iGPU passthrough..."
     
     local lxc_conf="/etc/pve/lxc/${CT_ID}.conf"
     
     if [ "$DRY_RUN" = false ]; then
+        if [ ! -c "$SELECTED_RENDER_NODE" ]; then
+            error_exit "Selected render node '$SELECTED_RENDER_NODE' does not exist or is not a character device on the host."
+        fi
+
+        # Get render group GID from host to pass through to container
+        local render_gid
+        render_gid=$(getent group render 2>/dev/null | cut -d: -f3)
+        if [ -z "$render_gid" ]; then
+            render_gid=$(stat -c '%g' "$SELECTED_RENDER_NODE")
+        fi
+
+        # Find the next free dev slot in the LXC config
+        local dev_slot=0
+        while grep -q "^dev${dev_slot}:" "$lxc_conf" 2>/dev/null; do
+            dev_slot=$((dev_slot + 1))
+        done
+
+        # Use Proxmox 8.2+ dev[n] passthrough (replaces cgroup2 + mount.entry approach)
+        # gid= sets the device node's group GID inside the container
         cat >> "$lxc_conf" << EOF
 
-# Frigate: iGPU Passthrough + AppArmor
-lxc.cgroup2.devices.allow: c 226:* rwm
-lxc.mount.entry: /dev/dri dev/dri none bind,optional,create=dir
-lxc.apparmor.profile = unconfined
+# Frigate: Minimal iGPU passthrough (selected render node only)
+dev${dev_slot}: $SELECTED_RENDER_NODE,gid=$render_gid
 EOF
-        log_success "iGPU passthrough and Apparmor profile configured in $lxc_conf"
+        log_success "iGPU passthrough configured (dev${dev_slot}: $(basename "$SELECTED_RENDER_NODE"), gid=$render_gid)"
+        log_warn "Note: GPU stats (e.g. intel_gpu_top) are not visible inside an unprivileged container. Hardware acceleration still works."
         REBOOT_REQUIRED=true
     else
-        log_dry_run "Add iGPU passthrough and Apparmor configuration to $lxc_conf"
+        log_dry_run "Add minimal iGPU passthrough configuration to $lxc_conf"
     fi
 }
 
@@ -1192,6 +1321,20 @@ $deploy_config"
     fi
     
     if [ "$DRY_RUN" = false ]; then
+        local FRIGATE_RTSP_PASSWORD
+        FRIGATE_RTSP_PASSWORD=$(openssl rand -hex 16)
+
+        local group_add_config=""
+        if [ "$ENABLE_IGPU" = "yes" ] && [ "$SELECTED_GPU_TYPE" != "nvidia" ]; then
+            local render_gid
+            render_gid=$(getent group render 2>/dev/null | cut -d: -f3)
+            if [ -z "$render_gid" ]; then
+                render_gid=$(stat -c '%g' "$SELECTED_RENDER_NODE")
+            fi
+            group_add_config="    group_add:
+      - \"$render_gid\""
+        fi
+
         pct exec "$CT_ID" -- bash -c "cat > /opt/frigate/compose.yml" << EOF
 version: "3.9"
 
@@ -1212,22 +1355,65 @@ services:
           size: 1000000000
     ports:
       - "$FRIGATE_PORT:$FRIGATE_PORT"
-      - "8554:8554"  # RTSP feeds
-      - "8555:8555/tcp"  # WebRTC
-      - "8555:8555/udp"  # WebRTC
-      - "$GO2RTC_PORT:$GO2RTC_PORT"  # go2rtc API
-      - "$AUTH_PORT:$AUTH_PORT"  # Frigate Auth port
 $device_config
     environment:
-      - FRIGATE_RTSP_PASSWORD=password
+      - FRIGATE_RTSP_PASSWORD=$FRIGATE_RTSP_PASSWORD
       - CONFIG_FILE=/config/config.yml
     cap_add:
       - CAP_PERFMON
     shm_size: "$SHM_SIZE"
+$group_add_config
 EOF
         log_success "compose.yml created"
     else
         log_dry_run "Create compose.yml"
+    fi
+}
+
+export_yolo_model() {
+    if [ "$ENABLE_YOLO_MODEL" = false ]; then
+        return
+    fi
+
+    log_step "Exporting YOLOv9-${YOLO_MODEL_SIZE} ONNX model (this may take several minutes)..."
+
+    local model_dir="/opt/frigate/config/model_cache/yolo"
+    local model_file="yolov9-${YOLO_MODEL_SIZE}-${YOLO_IMG_SIZE}.onnx"
+
+    if [ "$DRY_RUN" = false ]; then
+        pct exec "$CT_ID" -- mkdir -p "$model_dir"
+
+        pct exec "$CT_ID" -- bash -s << EXPORTSCRIPT
+cd "$model_dir"
+docker build --build-arg MODEL_SIZE=${YOLO_MODEL_SIZE} --build-arg IMG_SIZE=${YOLO_IMG_SIZE} --output . - << 'DOCKERFILE'
+FROM python:3.11 AS build
+RUN apt-get update && apt-get install --no-install-recommends -y cmake libgl1
+COPY --from=ghcr.io/astral-sh/uv:0.10.4 /uv /bin/
+WORKDIR /yolov9
+ADD https://github.com/WongKinYiu/yolov9.git .
+# torch<2.6: weights_only default changed to True in 2.6, breaking YOLOv9's torch.load calls in models/experimental.py
+RUN uv pip install --system "torch<2.6" -r requirements.txt
+RUN uv pip install --system onnx==1.18.0 onnxruntime onnx-simplifier onnxscript
+ARG MODEL_SIZE
+ARG IMG_SIZE
+ADD https://github.com/WongKinYiu/yolov9/releases/download/v0.1/yolov9-\${MODEL_SIZE}-converted.pt yolov9-\${MODEL_SIZE}.pt
+RUN python3 export.py --weights ./yolov9-\${MODEL_SIZE}.pt --imgsz \${IMG_SIZE} --simplify --include onnx
+FROM scratch
+ARG MODEL_SIZE
+ARG IMG_SIZE
+COPY --from=build /yolov9/yolov9-\${MODEL_SIZE}.onnx /yolov9-\${MODEL_SIZE}-\${IMG_SIZE}.onnx
+DOCKERFILE
+EXPORTSCRIPT
+
+        if pct exec "$CT_ID" -- test -f "$model_dir/$model_file"; then
+            log_success "Model exported: $model_file"
+        else
+            log_warn "YOLO model export failed. Falling back to default SSD model."
+            log_warn "You can export manually later and update config.yml."
+            ENABLE_YOLO_MODEL=false
+        fi
+    else
+        log_dry_run "Export YOLOv9-${YOLO_MODEL_SIZE} (${YOLO_IMG_SIZE}px) ONNX model inside container"
     fi
 }
 
@@ -1267,13 +1453,34 @@ create_frigate_config() {
   coral:
     type: edgetpu
     device: pci"
-    elif [ "$SELECTED_GPU_TYPE" = "intel" ]; then
+    elif [ "$SELECTED_GPU_TYPE" = "intel" ] || [ "$SELECTED_GPU_TYPE" = "amd" ] || [ "$SELECTED_GPU_TYPE" = "vaapi" ]; then
         detector_config="detectors:
   ov:
     type: openvino
-    device: GPU
+    device: GPU"
+        if [ "$ENABLE_YOLO_MODEL" = false ]; then
+            detector_config="$detector_config
     model:
       path: /openvino-model/ssdlite_mobilenet_v2.xml"
+        fi
+    fi
+
+    local yolo_model_config=""
+    if [ "$ENABLE_YOLO_MODEL" = true ]; then
+        yolo_model_config="model:
+  model_type: yolo-generic
+  width: $YOLO_IMG_SIZE
+  height: $YOLO_IMG_SIZE
+  input_tensor: nchw
+  input_dtype: float
+  path: $YOLO_MODEL_PATH
+  labelmap_path: /labelmap/coco-80.txt"
+    elif [ "$SELECTED_GPU_TYPE" = "intel" ] || [ "$SELECTED_GPU_TYPE" = "amd" ] || [ "$SELECTED_GPU_TYPE" = "vaapi" ]; then
+        # Frigate 0.17+ defaults to 320x320 tensor input; SSD MobileNet requires explicit 300x300
+        yolo_model_config="model:
+  width: 300
+  height: 300
+  path: /openvino-model/ssdlite_mobilenet_v2.xml"
     fi
 
     if [ "$DRY_RUN" = false ]; then
@@ -1286,6 +1493,8 @@ $go2rtc_config
 $hwaccel_config
 
 $detector_config
+
+$yolo_model_config
 
 cameras:
 $camera_template
@@ -1349,78 +1558,6 @@ setup_ssh() {
     log_success "SSH configured for user: $SSH_USER"
 }
 
-setup_samba() {
-    if [ "$ENABLE_SAMBA" != "yes" ]; then
-        log "Skipping Samba setup (disabled)"
-        return
-    fi
-    
-    log_step "Setting up Samba file sharing..."
-    
-    execute_in_container "DEBIAN_FRONTEND=noninteractive apt-get install -y samba"
-    
-    # Backup original config
-    execute_in_container "cp /etc/samba/smb.conf /etc/samba/smb.conf.bak"
-    
-    # Create Samba configuration
-    if [ "$DRY_RUN" = false ]; then
-        pct exec "$CT_ID" -- bash -c "cat > /etc/samba/smb.conf" << 'EOF'
-[global]
-netbios name = FRIGATE
-server string = Frigate NVR File Share
-workgroup = WORKGROUP
-security = user
-map to guest = Bad User
-guest account = nobody
-
-[Frigate]
-path = /opt/frigate
-comment = Frigate installation directory
-browsable = yes
-read only = no
-guest ok = yes
-public = yes
-writable = yes
-force user = root
-create mask = 0644
-directory mask = 0755
-
-[Config]
-path = /opt/frigate/config
-comment = Frigate configuration files
-browsable = yes
-read only = no
-guest ok = yes
-public = yes
-writable = yes
-force user = root
-create mask = 0644
-directory mask = 0755
-
-[Media]
-path = /opt/frigate/storage
-comment = Frigate media storage
-browsable = yes
-read only = no
-guest ok = yes
-public = yes
-writable = yes
-force user = root
-create mask = 0644
-directory mask = 0755
-EOF
-    fi
-    
-    # Set permissions
-    execute_in_container "chmod -R 777 /opt/frigate/storage"
-    
-    # Restart Samba
-    execute_in_container "systemctl restart smbd"
-    execute_in_container "systemctl enable smbd"
-    
-    log_success "Samba configured"
-}
-
 setup_extra_disk() {
     if [ "$ADD_EXTRA_DISK" != true ]; then
         return
@@ -1436,9 +1573,11 @@ setup_extra_disk() {
         done
         
         log "Using mount point mp$mp_id on $EXTRA_DISK_STORAGE"
-        pct set "$CT_ID" "-mp$mp_id" "$EXTRA_DISK_STORAGE:$EXTRA_DISK_SIZE,mp=/opt/frigate/storage" 2>&1 | tee -a "$LOG_FILE" || log_warn "Failed to add extra disk. Using rootfs instead."
-        
-        log_success "Extra disk added and mounted to /opt/frigate/storage"
+        if pct set "$CT_ID" "--mp${mp_id}" "${EXTRA_DISK_STORAGE}:${EXTRA_DISK_SIZE},mp=/opt/frigate/storage" 2>&1 | tee -a "$LOG_FILE"; then
+            log_success "Extra disk added and mounted to /opt/frigate/storage"
+        else
+            log_warn "Failed to add extra disk. Using rootfs instead."
+        fi
     else
         log_dry_run "Add $EXTRA_DISK_SIZE GB disk to $CT_ID on $EXTRA_DISK_STORAGE"
     fi
@@ -1457,6 +1596,86 @@ create_snapshot() {
         log_success "Snapshot created"
     else
         log_dry_run "Create snapshot $SNAPSHOT_NAME for container $CT_ID"
+    fi
+}
+
+# ============================================================================
+setup_samba() {
+    if [ "$ENABLE_SAMBA" != "yes" ]; then
+        log "Skipping Samba setup (disabled)"
+        return
+    fi
+
+    log_step "Setting up Samba file sharing..."
+
+    execute_in_container "DEBIAN_FRONTEND=noninteractive apt-get install -y samba"
+
+    # Create a dedicated non-root samba user
+    execute_in_container "id frigate &>/dev/null || useradd -M -s /usr/sbin/nologin frigate"
+    execute_in_container "chown -R frigate:frigate /opt/frigate/config /opt/frigate/storage"
+    execute_in_container "chmod -R 750 /opt/frigate/config /opt/frigate/storage"
+
+    if [ "$DRY_RUN" = false ]; then
+        pct exec "$CT_ID" -- bash -c "printf '%s\n%s\n' '$SAMBA_PASSWORD' '$SAMBA_PASSWORD' | smbpasswd -a -s frigate"
+
+        pct exec "$CT_ID" -- bash -c "cat > /etc/samba/smb.conf" << 'EOF'
+[global]
+netbios name = FRIGATE
+server string = Frigate NVR
+workgroup = WORKGROUP
+security = user
+map to guest = Never
+server min protocol = SMB2
+
+[Config]
+path = /opt/frigate/config
+comment = Frigate configuration files
+browsable = yes
+read only = no
+valid users = frigate
+force user = frigate
+create mask = 0640
+directory mask = 0750
+
+[Storage]
+path = /opt/frigate/storage
+comment = Frigate recordings and snapshots
+browsable = yes
+read only = no
+valid users = frigate
+force user = frigate
+create mask = 0640
+directory mask = 0750
+EOF
+    fi
+
+    execute_in_container "systemctl restart smbd && systemctl enable smbd"
+    log_success "Samba configured (user: frigate, shares: Config + Storage)"
+}
+
+setup_firewall() {
+    if [ "$ENABLE_FIREWALL" != "yes" ]; then
+        log "Skipping firewall setup (disabled)"
+        return
+    fi
+
+    log_step "Configuring Proxmox firewall for container $CT_ID..."
+
+    local fw_dir="/etc/pve/firewall"
+    local fw_file="$fw_dir/${CT_ID}.fw"
+
+    if [ "$DRY_RUN" = false ]; then
+        mkdir -p "$fw_dir"
+        cat > "$fw_file" << EOF
+[OPTIONS]
+enable: 1
+
+[RULES]
+IN ACCEPT -p tcp --dport $FRIGATE_PORT -log nolog # Frigate web UI
+EOF
+        log_success "Firewall enabled: port $FRIGATE_PORT (TCP) open"
+    else
+        log_dry_run "Create $fw_file and enable firewall on container"
     fi
 }
 
@@ -1492,13 +1711,14 @@ main() {
     
     create_frigate_directories
     create_docker_compose
+    export_yolo_model
     create_frigate_config
     
     start_frigate
     
     setup_ssh
     setup_samba
-    
+    setup_firewall
     create_snapshot
 
     echo ""
@@ -1516,8 +1736,8 @@ main() {
     echo ""
     
     if [ "$REBOOT_REQUIRED" = true ]; then
-        echo -e "${YELLOW}[IMPORTANT]${NC} A reboot of the Proxmox HOST is recommended to"
-        echo "ensure all GPU passthrough settings and drivers are fully active."
+        echo -e "${YELLOW}[INFO]${NC} GPU passthrough configured. If the container does not"
+        echo "detect the GPU, restart it with: pct restart $CT_ID"
     fi
     
     echo ""

--- a/update.sh
+++ b/update.sh
@@ -210,15 +210,15 @@ echo "Updating container $CT_ID to version $VERSION..."
 
 # update docker-compose.yml inside the container using sed
 # We look for the image: line and replace the tag
-pct exec "$CT_ID" -- bash -c "sed -i 's|image: ghcr.io/blakeblackshear/frigate:.*|image: ghcr.io/blakeblackshear/frigate:$VERSION|' /opt/frigate/docker-compose.yml"
+pct exec "$CT_ID" -- bash -c "sed -i 's|image: ghcr.io/blakeblackshear/frigate:.*|image: ghcr.io/blakeblackshear/frigate:$VERSION|' /opt/frigate/compose.yml"
 # Remove obsolete version line to suppress warnings
-pct exec "$CT_ID" -- bash -c "sed -i '/^version:/d' /opt/frigate/docker-compose.yml"
+pct exec "$CT_ID" -- bash -c "sed -i '/^version:/d' /opt/frigate/compose.yml"
 
 echo "Pulling new image..."
-pct exec "$CT_ID" -- docker compose -f /opt/frigate/docker-compose.yml pull
+pct exec "$CT_ID" -- docker compose -f /opt/frigate/compose.yml pull
 
 echo "Recreating container..."
-pct exec "$CT_ID" -- docker compose -f /opt/frigate/docker-compose.yml up -d
+pct exec "$CT_ID" -- docker compose -f /opt/frigate/compose.yml up -d
 
 
 echo -e "${GREEN}Update complete!${NC}"


### PR DESCRIPTION
## Summary

This PR improves security, robustness, and feature coverage of the install script.

**Security & container**
- Switch to unprivileged LXC with `keyctl=1` and `nesting=1` features
- Replace the broad `cgroup2` + AppArmor passthrough approach with the Proxmox 8.2+ `dev[n]` method (passes only the selected render node, with the correct host GID)
- Document that GPU statistics (e.g. `intel_gpu_top`) are not accessible from inside an unprivileged container; hardware acceleration still works

**Networking**
- Auto-detect available Proxmox bridges (`vmbr*` only — internal `fwbr*` firewall bridges are filtered out)
- Add optional VLAN tag and MTU configuration
- Add Proxmox firewall support: firewall enabled on the NIC at container creation, `.fw` ruleset created with port 5000 open by default

**Features**
- Add optional YOLOv9 ONNX model export via Docker BuildKit for OpenVINO detectors (sizes t/s/m/c/e, 320 or 640px)
- Pin `torch<2.6` in the export Dockerfile — PyTorch 2.6 changed `weights_only` default to `True`, breaking YOLOv9's `torch.load` calls
- Generate a random RTSP password instead of hardcoding `'password'`
- Add secured Samba file sharing: dedicated `frigate` system user, password always required, SMB2+ enforced, only `Config` and `Storage` shares exposed (no full install directory)

**Bug fixes**
- Fix storage pool usage percentage comparison (strip decimals before integer compare)
- Fix `pct set` flag syntax for extra disk (`--mp{n}`)
- Fix `net_config` construction for static vs DHCP (avoid `ip=dhcp=...` concatenation bug)
- Fix `update.sh` to reference `compose.yml` instead of the old `docker-compose.yml`
- Expand accepted container ID range from 100–999 to 100–9999

## Test plan

- [ ] Fresh install on Proxmox 8.2+ with Intel iGPU — verify unprivileged container starts and GPU passthrough works
- [ ] Verify Frigate detects the render node inside the container (`ls -l /dev/dri/`)
- [ ] Verify Proxmox firewall shows "Firewall: Yes" and port 5000 rule in the UI
- [ ] Test bridge auto-detection with multiple `vmbr*` bridges present
- [ ] Test VLAN and MTU options
- [ ] Test YOLOv9 export (small model, 640px) and verify Frigate loads the ONNX model
- [ ] Test Samba shares with the `frigate` user from Windows/macOS
- [ ] Run `update.sh` on an existing container and verify image pull works

🤖 Generated with [Claude Code](https://claude.com/claude-code)